### PR TITLE
feat: Redirect user to inbox after deleting an email

### DIFF
--- a/src/components/EmailDetail/EmailDetail.jsx
+++ b/src/components/EmailDetail/EmailDetail.jsx
@@ -8,6 +8,8 @@ import "./styles.css"
 
 export default function EmailDetail({emailIDClicked, setEmailIDClicked}) {
     const { data, error, sendMessage, resetAll} = useSendMessage("GET_MESSAGE");
+    // New Line: For deleting the email
+    const { sendMessage: deleteMessage } = useSendMessage("DELETE_MESSAGE"); 
 
     useEffect(() => {
         sendMessage({id: emailIDClicked});
@@ -23,6 +25,20 @@ export default function EmailDetail({emailIDClicked, setEmailIDClicked}) {
                 <div className="maildetail-container">
                     <div className="maildetail-header">
                         <h2>Subject: {data.subject}</h2>
+                        
+                        {/* NEW DELETE BUTTON ADDED HERE */}
+                        <button onClick={() => {
+                            // 1. Call delete function
+                            deleteMessage({id: emailIDClicked}); 
+                            
+                            // 2. ISSUE FIX: Redirect back to inbox by closing detail view
+                            setEmailIDClicked(null); 
+                            resetAll();
+                        }}>
+                            Delete
+                        </button>
+                        
+                        {/* EXISTING CLOSE BUTTON */}
                         <button onClick={() => {
                             setEmailIDClicked(null);
                             resetAll();


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the user remains on the detail page after deleting an email, as reported in Issue #6.

### Changes
- Added the `deleteMessage` call and immediately set `setEmailIDClicked(null)` inside the delete button's `onClick` handler in `EmailDetail.jsx`.
- This logic ensures the detail view closes and the user is navigated back to the Inbox view immediately after the delete action.

### Fixes
- Fixes #6