### PR TITLE
fix: correct icon paths in manifest for extension bar visibility (fix…

### DIFF
--- a/manifest.config.js
+++ b/manifest.config.js
@@ -6,9 +6,9 @@ export default defineManifest({
   name: pkg.name,
   version: pkg.version,
   icons: {
-    24: 'public/icons/icon24.ico',
-    48: 'public/icons/icon48.ico',
-    96: 'public/icons/icon96.ico',
+    24: 'icons/icon24.ico', // FIXED: Removed 'public/'
+    48: 'icons/icon48.ico', // FIXED: Removed 'public/'
+    96: 'icons/icon96.ico', // FIXED: Removed 'public/'
   },
   permissions: [
     "tabs",
@@ -19,9 +19,9 @@ export default defineManifest({
   ],
   action: {
     default_icon: {
-      24: 'public/icons/icon24.ico',
-      48: 'public/icons/icon48.ico',
-      96: 'public/icons/icon96.ico',
+     24: 'icons/icon24.ico', // FIXED: Removed 'public/'
+      48: 'icons/icon48.ico', // FIXED: Removed 'public/'
+      96: 'icons/icon96.ico', // FIXED: Removed 'public/'
     },
   },
   content_scripts: [{


### PR DESCRIPTION
## What does this PR do?

- Fixes #11

This PR fixes a bug where the extension icon fails to display in the Chrome extension bar.

## Technical Changes

The issue was that the icon paths in `manifest.config.js` were incorrectly prefixed with `public/`. 

When using the `@crxjs/vite-plugin` (Vite), the `public/` folder is treated as the asset root. By including `public/` in the path (e.g., `public/icons/icon24.ico`), the path resolution failed.

The fix removes the redundant `public/` prefix from all icon references in the `icons` and `action.default_icon` objects in `manifest.config.js`.

**Example Change:**
- Before: `'public/icons/icon24.ico'`
- After: `'icons/icon24.ico'`

## Visual Demo

N/A (This fix is related to the extension manifest and configuration, not the visible UI of the app content itself.)

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] N/A
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.